### PR TITLE
Fix/generator

### DIFF
--- a/inc/generator.hpp
+++ b/inc/generator.hpp
@@ -250,6 +250,33 @@ public:
    *  \param[in] p The promise to use.
    */
   generator(promise_type &p) : _h{handle_type::from_promise(p)} {}
+
+  /**
+   *  \brief Copy-constructing generators results in undefined behaviour.
+   */
+  generator(const generator &other) = delete;
+  /**
+   *  \brief Moves the data from the other generator into this one.
+   *  \param[in,out] other The other generator.
+   */
+  generator(generator &&other) = default;
+
+  /**
+   *  \brief Copy-assigning generators results in undefined behaviour.
+   */
+  generator &operator=(const generator &other) = delete;
+  /**
+   *  \brief Moves the data from the other generator into this one.
+   *  \param[in,out] other The other generator.
+   *  \returns A reference to this generator.
+   */
+  generator &operator=(generator &&other) = default;
+
+  /**
+   *  \brief Cleans up this generator's resources.
+   */
+  ~generator() = default;
+
   /**
    *  \brief Converts this generator its handle.
    *  \returns The handle for this generator.

--- a/test/Makefile
+++ b/test/Makefile
@@ -14,7 +14,7 @@ dirs:
 
 $(BIND)/generator: $(OBJD)/generator/test_generator.o
 	$(CC) $< $(LDXTRA) $(LDARGS) -o $@
-	$(BIND)/generator
+	$(BIND)/generator --gtest_output="xml:$(BIND)/"
 
 $(OBJD)/%.o: $(SRCD)/%.cpp Makefile
 	$(CC) $(CXXARGS) $(CXXXTRA) $< -o $@


### PR DESCRIPTION
Generator fix (mostly to disable copy constructing/assigning)